### PR TITLE
Revert back to latest pyChromecast version dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ You can see a mockup of the module [in this page](https://ferferga.github.io/MMM
 **Step 1**: One-line installation through terminal:
 
 ``
-sudo apt install python3 python3-pip -y && sudo apt clean && cd ~/MagicMirror/modules && git clone https://github.com/ferferga/MMM-GoogleCast.git && cd MMM-GoogleCast && sudo pip3 install -r requirements.txt && npm install && echo "Installation succesfull"
+sudo apt install python3 python3-pip -y && sudo apt clean && cd ~/MagicMirror/modules && git clone https://github.com/ferferga/MMM-GoogleCast.git && cd MMM-GoogleCast && sudo pip3 install pychromecast && npm install && echo "Installation succesfull"
 ``
 
 **Step 2**: If you see the message "Installation successfull", the first step is done! Now run:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,0 @@
-zeroconf==0.24.3
-PyChromecast==4.1.0


### PR DESCRIPTION
Due to #7 , I needed to enforce an specific version of pyChromecast and zeroconf, as a change in zeroconf altered the way pyChromecast worked.

As this issue was fixed in balloob/pychromecast#337, I'm reverting back to using always the latest version of pyChromecast, which is a good idea in this use case imo because I'm not using stuff that will probably break in future pyChromecast versions, while we're still getting some benefits and improvements from the most recent versions.